### PR TITLE
Various refactoring

### DIFF
--- a/doc/vimsence.txt
+++ b/doc/vimsence.txt
@@ -37,6 +37,13 @@ can use this: >
 This will force update the Discord presence with what you're currently
 editing.
 
+Manually reconnecting, either because Discord wasn't running or something
+else forced the connection to be closed, can be done with: >
+
+    :DiscordReconnect
+
+This will also attempt to close an existing session, if one exists.
+
 ==============================================================================
 3. License                                                   *VimSenceLicense*
 

--- a/plugin/vimsence.vim
+++ b/plugin/vimsence.vim
@@ -23,6 +23,10 @@ function! UpdatePresence()
     python3 vimsence.update_presence()
 endfunction
 
+function! DiscordReconnect()
+    python3 vimsence.reconnect()
+endfunction
+
 command! -nargs=0 UpdatePresence call UpdatePresence()
 
 augroup DiscordPresence

--- a/python/rpc.py
+++ b/python/rpc.py
@@ -174,7 +174,7 @@ class WinDiscordIpcClient(DiscordIpcClient):
         self.path = path
 
     def _write(self, data: bytes):
-        if self._f:
+        if hasattr(self, '_f'):
             self._f.write(data)
             self._f.flush()
 
@@ -182,7 +182,7 @@ class WinDiscordIpcClient(DiscordIpcClient):
         return self._f.read(size)
 
     def _close(self):
-        if self._f:
+        if hasattr(self, '_f'):
             self._f.close()
 
 

--- a/python/rpc.py
+++ b/python/rpc.py
@@ -106,6 +106,7 @@ class DiscordIpcClient(metaclass=ABCMeta):
         try: 
             self._connect()
             self._do_handshake()
+            logger.info("Successfully connected to Discord.")
         except Exception:
             logger.error("Failed to connect. Is Discord running?")
             pass

--- a/python/rpc.py
+++ b/python/rpc.py
@@ -94,6 +94,20 @@ class DiscordIpcClient(metaclass=ABCMeta):
         finally:
             self._close()
 
+    def reconnect(self):
+        try:
+            # Attempt to close the connection.
+            self.close()
+        except: 
+            # Ignore if it fails - the socket probably isn't initialized.
+            pass
+        try: 
+            self._connect()
+        except Exception:
+            logger.error("Failed to connect. Is Discord running?")
+            pass
+        
+
     @abstractmethod
     def _close(self):
         pass
@@ -148,7 +162,7 @@ class WinDiscordIpcClient(DiscordIpcClient):
             try:
                 self._f = open(path, "w+b")
             except OSError as e:
-                logger.error("failed to open {!r}: {}".format(path, e))
+                pass
             else:
                 break
         else:

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -28,6 +28,9 @@ except Exception as e:
     # Discord is not running
     pass
 
+def reconnect():
+    rpc_obj.reconnect()
+
 def update_presence():
     """Update presence in Discord
     """

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -18,7 +18,8 @@ base_activity = {
 client_id = '439476230543245312'
 
 has_thumbnail = [
-    'c', 'cr', 'hs', 'json', 'nim', 'rb', 'cpp', 'go', 'js', 'md', 'ts', 'py', 'vim', 'rs', 'css', 'html', 'vue'
+    'c', 'cr', 'hs', 'json', 'nim', 'rb', 'cpp', 'hpp', 'go', 'js', 'md', 'ts', 'py',
+    'vim', 'rs', 'css', 'html', 'vue'
 ]
 
 
@@ -26,34 +27,46 @@ try:
     rpc_obj = rpc.DiscordIpcClient.for_platform(client_id)
     rpc_obj.set_activity(base_activity)
 except Exception as e:
-    # Discord is not running
+    # Discord is not running.
+    # The session is initialized and can be re-used later.
     pass
 
-def reconnect():
-    if rpc_obj is None:
-        create();
-    rpc_obj.reconnect()
 
 def update_presence():
     """Update presence in Discord
     """
-    activity = base_activity 
+    activity = base_activity
 
     large_image = ""
     large_text = ""
     details = ""
     state = ""
 
-    if get_extension() and get_extension() in has_thumbnail:
-        large_image = get_extension()
-        large_text = 'Editing a {} file'.format(get_extension())
-        details = 'Editing {}'.format(get_filename())
-        state = 'Workspace: {}'.format(get_directory())
-    elif get_filename() == 'vimfiler:default':
+    filename = get_filename()
+    directory = get_directory()
+    extension = get_extension()
+
+    if extension and extension in has_thumbnail:
+        if extension == "hpp":
+            large_image = "cpp"
+        else:
+            large_image = extension
+        large_text = 'Editing a {} file'.format(extension)
+        details = 'Editing {}'.format(filename)
+        state = 'Workspace: {}'.format(directory)
+    elif filename.startswith("."):
+        if filename in has_thumbnail:
+            large_image = filename
+        else:
+            large_image = "none"
+        large_text = 'Editing a {} file'.format(filename)
+        details = 'Editing {}'.format(filename)
+        state = 'Workspace: {}'.format(directory)
+    elif filename == 'vimfiler:default' or "NERD_tree_" in filename == 'NERD_tree_2':
         large_image = 'file-explorer'
         large_text = 'In the file explorer'
         details = 'Searching for files'
-        state = 'Workspace: {}'.format(get_directory())
+        state = 'Workspace: {}'.format(directory)
     else:
         large_image = 'none'
         large_text = 'Nothing'
@@ -75,6 +88,10 @@ def update_presence():
     except OSError as e:
         # IO-related issues (possibly disconnected)
         pass
+
+def reconnect():
+    if rpc_obj.reconnect():
+        update_presence()
 
 def get_filename():
     """Get current filename that is being edited

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -21,6 +21,7 @@ has_thumbnail = [
     'c', 'cr', 'hs', 'json', 'nim', 'rb', 'cpp', 'go', 'js', 'md', 'ts', 'py', 'vim', 'rs', 'css', 'html', 'vue'
 ]
 
+
 try:
     rpc_obj = rpc.DiscordIpcClient.for_platform(client_id)
     rpc_obj.set_activity(base_activity)
@@ -29,6 +30,8 @@ except Exception as e:
     pass
 
 def reconnect():
+    if rpc_obj is None:
+        create();
     rpc_obj.reconnect()
 
 def update_presence():
@@ -68,6 +71,9 @@ def update_presence():
         pass
     except NameError as e:
         # Discord is not running
+        pass
+    except OSError as e:
+        # IO-related issues (possibly disconnected)
         pass
 
 def get_filename():

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -83,4 +83,4 @@ def get_directory():
     """Get current directory
     :returns: string
     """
-    return vim.eval('expand("%:p:h:t")')
+    return vim.eval('getcwd()').split('/')[-1]

--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -2,6 +2,7 @@ import vim
 import rpc
 import time
 import logging
+import re
 
 start_time = int(time.time())
 base_activity = {
@@ -62,7 +63,7 @@ def update_presence():
         large_text = 'Editing a {} file'.format(filename)
         details = 'Editing {}'.format(filename)
         state = 'Workspace: {}'.format(directory)
-    elif filename == 'vimfiler:default' or "NERD_tree_" in filename == 'NERD_tree_2':
+    elif filename == 'vimfiler:default' or "NERD_tree_" in filename:
         large_image = 'file-explorer'
         large_text = 'In the file explorer'
         details = 'Searching for files'
@@ -109,4 +110,4 @@ def get_directory():
     """Get current directory
     :returns: string
     """
-    return vim.eval('getcwd()').split('(\/)|(\\)')[-1]
+    return re.split(r"[\\/]", vim.eval('getcwd()'))[-1]


### PR DESCRIPTION
Failing to connect to Discord on Windows results in an error dialog on boot. This is not a problem on Unix (warnings are suppressed) - updated to match that. 

Additionally, I added a `:DiscordReconnect` command, which forces a reconnect. Useful if the session is terminated or never started. 

Windows suffered from a lack of error handling and threw AttributeErrors over `_f`. Sanity-checks are now in place to make sure the field exists, and it seems to be enough to avoid errors. Not sure how disconnected states are handled, but it should be fine. 

I also patched in `.hpp` to have the same icon has `.cpp`. `.hpp` is a header extension frequently used with C++. `.h` can be used with both C and C++, which is why I didn't do the same for `.h`. 
Some better handling could be done by grabbing the filetype from something else than the extension ([`echo &filetype`](https://stackoverflow.com/a/52133802/6296561)). This should in theory get the assigned file type, which means it could go a lot further than manually checking the file extensions. For some languages, that's fine, but for others, there's several variants to check. I have no idea how do do that though, so I didn't. 

Also a performance fix: reducing the amount of calls and using cache variables in the update_presence method. Probably not a noticeable difference on such a small scale, but you never know.

Additionally, the last commit should enable proper workspace naming. It at least works on Windows - not sure if I broke Unix in the process (please sanity-check that before merging). 