### PR TITLE
Buffer type checking

### DIFF
--- a/doc/vimsence.txt
+++ b/doc/vimsence.txt
@@ -30,19 +30,31 @@ You just need to have this plugin installed and Discord running, the rest
 will work automatically.
 
 If you have to manually update your presence for some kind of reason, you
-can use this: >
-
+can use this:
+>
     :UpdatePresence
-
+<
 This will force update the Discord presence with what you're currently
 editing.
 
 Manually reconnecting, either because Discord wasn't running or something
-else forced the connection to be closed, can be done with: >
-
+else forced the connection to be closed, can be done with:
+>
     :DiscordReconnect
-
+<
 This will also attempt to close an existing session, if one exists.
+
+Additionally, both file types and directories can be ignored, which means
+they won't be displayed on Discord. Note that the file type variant uses
+file types, not file extensions. 
+The variable names used are:
+
+> 
+    g:vimsence_ignored_directories
+    g:vimsence_ignored_file_types 
+<
+
+These are expected to be arrays of strings. By default, these do not exclude any folders or file types.
 
 ==============================================================================
 3. License                                                   *VimSenceLicense*

--- a/python/utils.py
+++ b/python/utils.py
@@ -1,0 +1,31 @@
+# Type-safe approach to checking if an object contains another. 
+# This is intended for arrays, but falls back to equals for strings.
+# For arrays, it uses the "in" operator to check for the presence of
+# a specific item. 
+# If array or item is null, or the type of array isn't str or list, 
+# this returns false. Otherwise, it checks for the type, and runs an
+# appropriate comparison and returns the result. 
+def contains(array, item):
+    if (item is None or array is None):
+        return False
+    elif (type(array) is list):
+        return item in array
+    elif (type(array) is str):
+        return item == array
+    return False
+
+# Type safe contains method. 
+# Does the same as contains, except it uses "in" to check
+# for matches instead of requiring an exact match
+def contains_fuzzy(array, item):
+    if (item is None or array is None):
+        return False
+    elif (type(array) is list):
+        for a in array:
+            if a in item:
+                return True
+        return False
+    elif (type(array) is str):
+        return item in array
+    return False
+


### PR DESCRIPTION
This checks the filetype defined in the buffer rather than the extension. This aims to correct icons with non-standard file extensions to the language. 

One example of this: SCons (TL;DR: build system) uses a Python file called `SConstruct`. This file doesn't have a Python extension, but it is still a Python file, and can have the filetype set to Python either manually, or through autocmd. Using `&filetype` as the primary measure to get filetypes would here result in the Python icon. 

It also helps with languages such as markdown, where the extensions can be `.md`, `.markdown`, `.mdown`, and [several others](https://superuser.com/a/285878/623128). The three I mentioned, if `:echo &filetype` is executed, are all interpreted by vim as `markdown`. So this PR also helps unify various file extensions into a single line of code, rather than having to define them all.

Additionally, if a file is writeable and has a name, it'll show up. This adds support for other files without icons too. 