### PR TITLE
Log level change

### DIFF
--- a/python/rpc.py
+++ b/python/rpc.py
@@ -90,7 +90,7 @@ class DiscordIpcClient(metaclass=ABCMeta):
         return buf
 
     def close(self):
-        logger.warning("closing connection")
+        logger.debug("closing connection")
         try:
             self.send({}, op=OP_CLOSE)
         finally:


### PR DESCRIPTION
Closes #3 - it's not really an error, but an incorrect logging level makes it appear as one. This is probably because of how Vim interprets output streams. It probably doesn't need to be at a warning level either - probably better to disconnect quietly. 